### PR TITLE
CORS対策でproxy経由に変更

### DIFF
--- a/mixins/getAmount.js
+++ b/mixins/getAmount.js
@@ -7,8 +7,7 @@ export default Vue.extend({
   },
   methods: {
     amountUpdate: async function() {
-      this.Amount = await axios.get(`https://query1.finance.yahoo.com/v7/finance/chart/7203.T?range=1h&interval=1h`, {
-        headers: { "Access-Control-Allow-Origin": "*"},
+      this.Amount = await axios.get(`/api/v7/finance/chart/7203.T?range=1h&interval=1h`, {
         data: {}
       })
         .then((res) => res.data['chart']['result'][0]['indicators']['quote'][0]['close'][0] )

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -39,9 +39,21 @@ export default {
   // Modules: https://go.nuxtjs.dev/config-modules
   modules: [
     "@nuxtjs/axios",
+    "@nuxtjs/proxy",
   ],
 
   // Build Configuration: https://go.nuxtjs.dev/config-build
   build: {
-  }
+  },
+
+  proxy: {
+    '/api': {
+      target: 'https://query1.finance.yahoo.com',
+      changeOrigin: true,
+      secure: false,
+      pathRewrite: {
+        '^/api': '/'
+      }
+    }
+  },
 }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@nuxtjs/axios": "^5.13.1",
+    "@nuxtjs/proxy": "^2.1.0",
     "core-js": "^3.9.1",
     "node-sass": "^5.0.0",
     "nuxt": "^2.15.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1264,7 +1264,7 @@
 
 "@nuxtjs/proxy@^2.1.0":
   version "2.1.0"
-  resolved "https://registry.npmjs.org/@nuxtjs/proxy/-/proxy-2.1.0.tgz"
+  resolved "https://registry.yarnpkg.com/@nuxtjs/proxy/-/proxy-2.1.0.tgz#fa7715a11d237fa1273503c4e9e137dd1bf5575b"
   integrity sha512-/qtoeqXgZ4Mg6LRg/gDUZQrFpOlOdHrol/vQYMnKu3aN3bP90UfOUB3QSDghUUK7OISAJ0xp8Ld78aHyCTcKCQ==
   dependencies:
     http-proxy-middleware "^1.0.6"


### PR DESCRIPTION
# 概要

- @nuxtjs/proxyパッケージを追加
- `/api` にアクセスすると `https://query1.finance.yahoo.com` にアクセスするように設定

# 背景

- [プリフライトリクエスト（OPTIONS)](https://developer.mozilla.org/ja/docs/Glossary/Preflight_request)でブラウザ側でCORSエラーが出ていたため、対象のAPIはブラウザからの異なるドメインからのアクセスには対応していなかった。
- proxyを使用して同一ドメインにすることで、ブラウザ側のCORSエラーを回避した。
- asyncDataからアクセスできるのはNode.jsからのアクセスであるため、CORSエラーとは関係がないため。