### PR TITLE
更新ボタンを押して株価を表示

### DIFF
--- a/components/StockView.vue
+++ b/components/StockView.vue
@@ -1,7 +1,7 @@
 <template>
   <div class='box'>
     <h1>StockView</h1>
-    <input  placeholder="銘柄番号を入力してください" @keyup.enter="updateBrand">
+    <input placeholder="銘柄番号を入力してください" v-model="inputBrand" @change="updateBrand">
     <p>brand</p>
     <select v-model="selected" @change="updateBar">
       <option>1m</option>
@@ -12,8 +12,6 @@
     </select>
     <p>bar</p>
     <button @click="amountUpdate()">更新</button>
-    <p>props</p>
-    <p>{{ amount }}</p>
     <p>state</p>
     <p>{{ Amount }}</p>
   </div>
@@ -30,8 +28,8 @@ export default Vue.extend({
     stateAmount(): Number {
       return this.$store.getters['tasks/getAmount']
     },
-    updateBrand(e:any) {
-      this.$store.commit('tasks/updateBrand', e.target.value)
+    updateBrand() {
+      this.$store.commit('tasks/updateBrand', this.inputBrand)
     },
     updateBar() {
       this.$store.commit('tasks/updateBar', this.selected)

--- a/components/StockView.vue
+++ b/components/StockView.vue
@@ -12,8 +12,9 @@
     </select>
     <p>bar</p>
     <button @click="amountUpdate()">更新</button>
-    <p>state</p>
-    <p>{{ Amount }}</p>
+    <p>株価：{{ Amount }}</p>
+    <p>銘柄：{{ this.inputBrand }}</p>
+    <p>期間：{{ this.selected }}</p>
   </div>
 </template>
 


### PR DESCRIPTION
## 概要
- 更新ボタンを押すと、入力した銘柄と期間で株価が表示されるようにした

## やったこと
- 銘柄の`input`を修正
  -  v-modelで入力された値を取得できるようにした
- 上記で取得した値をstoreに渡す

## 課題
- inputタグに何も入力しないで更新すると、前回入力時の銘柄で株価が取得される
- 処理が中断されることはないがエラー出てる

```
Property 'selected' does not exist on type 'CombinedVueInstance<Vue, unknown, { stateAmount(): Number; updateBrand(): void; updateBar(): void; }, unknown, Readonly<{ amount: number; }>>'

Property or method "inputBrand" is not defined on the instance but referenced during render. Make sure that this property is reactive, either in the data option, or for class-based components, by initializing the property.
``` 